### PR TITLE
docs: remove founder callout from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ A serverless plugin to listen to offline SNS and call lambda fns with events.
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![All Contributors](https://img.shields.io/badge/all_contributors-34-orange.svg?style=flat-square)](#contributors)
 
-Originally created and maintained for nearly 10 years by [Matthew James](https://github.com/mj1618).
-
 ## Docs
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)


### PR DESCRIPTION
## What does this PR do and why?

Removes the separate founder callout from the README as requested in #251. Matthew James remains credited through the shared contributors list.

## Closes

Closes #251

## Checklist

- [x] This PR contains exactly one semantic commit
- [x] The commit message follows Conventional Commits (`docs:`)
- [x] Tests pass locally (`yarn lint`, `yarn test`, and `yarn build`)
